### PR TITLE
chore: Add VS Code task, settings. extensions and launch configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@ __pycache__/
 *.py[cod]
 .env
 .env.*
+.venv
 *.sqlite3
 alembic/versions/*.pyc
 *.log
-.vscode/
 .idea/
 *.db
 dist/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-python.autopep8",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debugger: FastAPI",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": [
+        "app.main:app", 
+        "--reload"
+      ],
+      "jinja": false
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.tabSize": 4, // sapce in tab
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8",
+    "editor.formatOnSave": true // Autosave formats the file
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run FastAPI",
+      "type": "shell",
+      "command": "uvicorn app.main:app --reload",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Migrations (Alembic Upgrade)",
+      "type": "shell",
+      "command": "alembic upgrade head",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
adds .vscode folder with extensions.json( so that all developers have recommended extensions like Python, Pylace, and Autopep8), launch.json( for debug fastapi), task.json( it has task for run fastapi  and task for  run migrations), and settings( to set autopep8 as default format) and added .venv to gitignore.
