### PR TITLE
chore: add docker compose, dev container and add docker explain in README file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim-bookworm
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libmariadb-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Crea el usuario antes de copiar archivos
+RUN useradd -m vscode
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install pymysql
+
+# Da permisos al usuario vscode sobre la carpeta de trabajo
+RUN chown -R vscode /workspace
+
+USER vscode
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "fastapi-app",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "remoteUser": "vscode",
+  "forwardPorts": [8000],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.autopep8",
+        "ms-python.vscode-pylance",
+        "ms-vscode-remote.remote-containers",
+        "ms-azuretools.vscode-docker",
+        "esbenp.prettier-vscode"
+
+      ]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  }
+}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,73 @@ alembic upgrade head
 uvicorn app.main:app --reload
 ```
 
+## 🐳 Uso de Docker Compose y Devcontainer
+
+Este proyecto soporta dos formas principales de desarrollo con Docker: usando **Docker Compose** directamente o usando el entorno de desarrollo remoto de **Devcontainer** en VS Code. Ambas opciones aíslan las dependencias y facilitan la colaboración.
+
+---
+
+### 🚀 Opción 1: Usar Docker Compose
+
+1. **Copia el archivo `.env` y edítalo** con tus credenciales de base de datos y variables necesarias.  
+   Un ejemplo de archivo `.env` para usar Docker Compose es:
+
+   ```env
+   DATABASE_URL=mysql+pymysql://user:password@db:3306/loopsociety
+   SECRET_KEY=supersecret
+   MYSQL_USER=user
+   MYSQL_ROOT_PASSWORD=password
+   MYSQL_PASSWORD=password
+   MYSQL_DATABASE=loopsociety
+   ```
+
+   > **Nota:**  
+   > Si solo quieres usar el servicio de base de datos (`db`) de Docker y correr FastAPI localmente (fuera de Docker), cambia `db` por `localhost` en la variable `DATABASE_URL`:
+   > ```
+   > DATABASE_URL=mysql+pymysql://user:password@localhost:3306/loopsociety
+   > ```
+
+2. **Levanta los servicios** (FastAPI y MySQL):
+
+   ```bash
+   docker-compose up --build
+   ```
+
+   Esto construirá la imagen, instalará dependencias y levantará la base de datos y la app.
+
+3. **Accede a la API** en [http://localhost:8000](http://localhost:8000).
+
+4. **Detén los servicios** con:
+
+   ```bash
+   docker-compose down
+   ```
+
+---
+
+### 💻 Opción 2: Usar Devcontainer en VS Code
+
+El devcontainer te permite desarrollar dentro de un contenedor con todas las herramientas y extensiones configuradas automáticamente.
+
+1. **Abre el proyecto en VS Code**.
+
+2. Si tienes la extensión [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) instalada, haz clic en la esquina inferior izquierda (><) y selecciona:
+
+   ```
+   Reopen in Container
+   ```
+
+   VS Code construirá el contenedor usando la configuración de `.devcontainer/`.
+
+3. **¡Listo!**  
+   El servidor FastAPI y las migraciones se ejecutan automáticamente al iniciar el contenedor.  
+   Solo tienes que abrir [http://localhost:8000](http://localhost:8000) en tu navegador para acceder a la API.
+
+   > **Tip:**  
+   > El servidor FastAPI se ejecuta con la opción `--reload`, lo que significa que cualquier cambio en el código fuente se reflejará automáticamente sin necesidad de reiniciar el contenedor.
+
+---
+
 ## 🛠️ ¿Cómo colaborar?
 1. Crea una rama nueva:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  app:
+    depends_on:
+      db:
+        condition: service_healthy
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    restart: unless-stopped
+    tty: true
+    container_name: fastapi_app
+    volumes:
+      - ./:/workspace
+    ports:
+      - 8000:8000
+    env_file:
+      - ./.env
+  db:
+    image: mysql:8.0.42-bookworm
+    container_name: fastapi_db
+    restart: always
+    ports:
+      - 3306:3306
+    volumes:
+      - db_data:/var/lib/mysql
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u$$MYSQL_USER", "-p$$MYSQL_PASSWORD"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  db_data:


### PR DESCRIPTION
in this pull request it was a dev container with the purpose of avoiding the phrase " on my machine if works", now the developer can work with the same specs in dev container,  work  with docker compose  or just use the db services for work with mysql. also it was add section in Readme that explain how make works the new chores.